### PR TITLE
Fix syntax error in database module

### DIFF
--- a/instavibe/db.py
+++ b/instavibe/db.py
@@ -2,8 +2,8 @@
 
 import os
 import traceback
-from datetime import datetime,
-import json # For example usage printing
+from datetime import datetime
+import json  # For example usage printing
 
 from google.cloud import spanner
 from google.cloud.spanner_v1 import param_types


### PR DESCRIPTION
## Summary
- correct typo in the `instavibe/db.py` imports

## Testing
- `python -m py_compile instavibe/db.py`
- `python -m py_compile instavibe/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688083720fac83238bc16e12c492fc0d