### PR TITLE
Fix location preference naming

### DIFF
--- a/instavibe/ally_routes.py
+++ b/instavibe/ally_routes.py
@@ -58,7 +58,7 @@ def submit_introvert_ally_request():
     """Handles the submission of the Introvert Ally form."""
     if request.method == 'POST':
         date = request.form.get('event_date')
-        location_preference = request.form.get('location') # Renamed for clarity
+        location_preference = request.form.get('location_preference')
         selected_friend_names_list = request.form.getlist('selected_friends')
 
         # Basic validation
@@ -70,7 +70,7 @@ def submit_introvert_ally_request():
         session['ally_request_params'] = {
             "user_name": "Alice", # Hardcoded for now
             "planned_date": date,
-            "location_n_perference": location_preference,
+            "location_preference": location_preference,
             "selected_friend_names_list": selected_friend_names_list
         }
         # Clear any old plan details
@@ -100,7 +100,7 @@ def stream_introvert_ally_plan():
             for event_data in call_agent_for_plan(
                 user_name=ally_params['user_name'],
                 planned_date=ally_params['planned_date'],
-                location_n_perference=ally_params['location_n_perference'],
+                location_preference=ally_params['location_preference'],
                 selected_friend_names_list=ally_params['selected_friend_names_list']
             ):
                 event_type = event_data.get("type", "thought") 

--- a/instavibe/introvertally.py
+++ b/instavibe/introvertally.py
@@ -9,7 +9,7 @@ load_dotenv()
 #REPLACE ME initiate agent_engine
 
 
-def call_agent_for_plan(user_name, planned_date, location_n_perference, selected_friend_names_list):
+def call_agent_for_plan(user_name, planned_date, location_preference, selected_friend_names_list):
     user_id = str(user_name)
     # agent_thoughts_log = [] # No longer needed here, we yield directly
 
@@ -17,9 +17,9 @@ def call_agent_for_plan(user_name, planned_date, location_n_perference, selected
     yield {"type": "thought", "data": f"Session ID for this run: {user_id}"}
     yield {"type": "thought", "data": f"User: {user_name}"}
     yield {"type": "thought", "data": f"Planned Date: {planned_date}"}
-    yield {"type": "thought", "data": f"Location/Preference: {location_n_perference}"}
+    yield {"type": "thought", "data": f"Location/Preference: {location_preference}"}
     yield {"type": "thought", "data": f"Selected Friends: {', '.join(selected_friend_names_list)}"}
-    yield {"type": "thought", "data": f"Initiating plan for {user_name} on {planned_date} regarding '{location_n_perference}' with friends: {', '.join(selected_friend_names_list)}."}
+    yield {"type": "thought", "data": f"Initiating plan for {user_name} on {planned_date} regarding '{location_preference}' with friends: {', '.join(selected_friend_names_list)}."}
 
     selected_friend_names_str = ', '.join(selected_friend_names_list)
     # print(f"Selected Friends (string for agent): {selected_friend_names_str}") # Console log
@@ -27,7 +27,7 @@ def call_agent_for_plan(user_name, planned_date, location_n_perference, selected
     # Constructing an example for the prompt, e.g., ["Alice", "Bob"]
     friends_list_example_for_prompt = json.dumps(selected_friend_names_list)
 
-    prompt_message = f"""Plan a personalized night out for {user_name} with friends {selected_friend_names_str} on {planned_date}, with the location or preference being "{location_n_perference}".
+    prompt_message = f"""Plan a personalized night out for {user_name} with friends {selected_friend_names_str} on {planned_date}, with the location or preference being "{location_preference}".
 
     Analyze friend interests (if possible, use Instavibe profiles or summarized interests) to create a tailored plan.  Ensure the plan includes the date {planned_date}.
 

--- a/instavibe/templates/introvert_ally.html
+++ b/instavibe/templates/introvert_ally.html
@@ -44,8 +44,8 @@
                 </div>
 
                 <div class="mb-3">
-                    <label for="location" class="form-label"><strong>Location:</strong></label>
-                    <input type="text" class="form-control" id="location" name="location" placeholder="e.g., Boston, San Francisco, etc." required>
+                    <label for="location_preference" class="form-label"><strong>Location:</strong></label>
+                    <input type="text" class="form-control" id="location_preference" name="location_preference" placeholder="e.g., Boston, San Francisco, etc." required>
                 </div>
 
                 <button type="submit" class="btn btn-primary w-100">Submit Hangout Request</button>


### PR DESCRIPTION
## Summary
- correct typos for `location_preference`
- update routes to use the new field and session key
- rename form field for location preference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688087384b208323be72c27c9d5992cc